### PR TITLE
Switch to our own class

### DIFF
--- a/fmt.cabal
+++ b/fmt.cabal
@@ -66,6 +66,7 @@ library
                        Fmt.Internal.Tuple
                        Fmt.Internal.Numeric
                        Fmt.Internal.Generic
+                       Fmt.Internal.See
 
   build-depends:       base >=4.6 && <5,
                        base64-bytestring,


### PR DESCRIPTION
### Code

* [ ] Mirror all `Buildable` instances
* [ ] Make sure that `Float` and `Double` instances aren't broken (in `formatting` they switch to expt way too early)
* [ ] Add tests or doctests for the above
* [ ] File a bug for `formatting`
* [ ] Remove the `formatting` dependency
* [ ] Make sure we have the necessary inlining
* [ ] Add a default `genericF` definition
* [ ] Add doctests for *all* instances
* [ ] Inlining everywhere

### Unsolved questions

* [ ] Can we make sure that we can write to both `Text` and `ByteString` builders?

### Misc

* [ ] Update changelog
* [ ] Update readme
* [ ] Update .cabal description