### PR TITLE
[#10] Add support for DerivingVia

### DIFF
--- a/lib/Fmt.hs
+++ b/lib/Fmt.hs
@@ -120,6 +120,7 @@ module Fmt
 
   -- ** Generic formatting
   genericF,
+  GenericBuildable(..),
 )
 where
 

--- a/lib/Fmt/Internal/Generic.hs
+++ b/lib/Fmt/Internal/Generic.hs
@@ -65,6 +65,27 @@ on it. It's merely a convenience function.
 genericF :: (Generic a, GBuildable (Rep a)) => a -> Builder
 genericF = gbuild . from
 
+{- | A newtype for deriving a generic 'Buildable' instance for any type
+using @DerivingVia@.
+
+>>> :set -XDerivingVia
+>>> :{
+data Bar = Bar { x :: Bool, y :: [Int] }
+  deriving stock Generic
+  deriving Buildable via GenericBuildable Bar
+:}
+
+>>> pretty (Bar True [1,2,3])
+Bar:
+  x: True
+  y: [1, 2, 3]
+
+-}
+newtype GenericBuildable a = GenericBuildable a
+
+instance (GBuildable (Rep a), Generic a) => Buildable (GenericBuildable a) where
+  build (GenericBuildable a) = genericF a
+
 ----------------------------------------------------------------------------
 -- GBuildable
 ----------------------------------------------------------------------------


### PR DESCRIPTION
As discussed [here](https://github.com/cdornan/fmt/issues/10#issuecomment-760063813), this PR adds a newtype `GenericBuildable`.

With this type, we can derive a generic `Buildable` instance in one line using `DerivingVia`.

Example:

```hs
>>> :set -XDerivingVia
>>> :{
data Bar = Bar { x :: Bool, y :: [Int] }
  deriving stock Generic
  deriving Buildable via GenericBuildable Bar
:}

>>> pretty (Bar True [1,2,3])
Bar:
  x: True
  y: [1, 2, 3]
```